### PR TITLE
Fixed Java compiler running before Kotlin compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,15 +25,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
             <!-- Kotlin -->
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
@@ -69,7 +60,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>3.6.1</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
                 <executions>
                     <!-- Replacing default-compile as it is treated specially by maven -->
                     <execution>


### PR DESCRIPTION
This commit fixes a slight oversight in the pom.xml, due to which the Java compiler was still running before the Kotlin compiler, giving compilation errors.